### PR TITLE
feat: DBバックアップ機能追加

### DIFF
--- a/ThemeManagement/Components/Layout/NavMenu.razor
+++ b/ThemeManagement/Components/Layout/NavMenu.razor
@@ -5,5 +5,6 @@
     <MudNavLink Href="/workdays" Icon="@Icons.Material.Filled.CalendarMonth">稼働日管理</MudNavLink>
     <MudNavLink Href="/themes" Icon="@Icons.Material.Filled.Topic">テーマ・案件</MudNavLink>
     <MudNavLink Href="/forecast" Icon="@Icons.Material.Filled.TableChart">半期見込計算</MudNavLink>
+    <MudNavLink Href="/settings" Icon="@Icons.Material.Filled.Settings">設定・管理</MudNavLink>
 </MudNavMenu>
 

--- a/ThemeManagement/Components/Pages/Settings/SettingsPage.razor
+++ b/ThemeManagement/Components/Pages/Settings/SettingsPage.razor
@@ -1,0 +1,29 @@
+@page "/settings"
+@rendermode InteractiveServer
+@inject NavigationManager Nav
+
+<PageTitle>設定・管理</PageTitle>
+
+<MudText Typo="Typo.h5" Class="mb-4">設定・管理</MudText>
+
+<MudGrid>
+    <MudItem xs="12" sm="6" md="4">
+        <MudPaper Class="pa-4" Elevation="2">
+            <MudStack Spacing="2">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                    <MudIcon Icon="@Icons.Material.Filled.Backup" Color="Color.Primary" />
+                    <MudText Typo="Typo.h6">DBバックアップ</MudText>
+                </MudStack>
+                <MudText Typo="Typo.body2" Color="Color.Secondary">
+                    現在のデータベースをSQLiteファイルとしてダウンロードします。<br />
+                    定期的なバックアップを推奨します。
+                </MudText>
+                <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                           StartIcon="@Icons.Material.Filled.Download"
+                           Href="/api/backup/download" Target="_blank">
+                    バックアップをダウンロード
+                </MudButton>
+            </MudStack>
+        </MudPaper>
+    </MudItem>
+</MudGrid>

--- a/ThemeManagement/Components/Pages/Settings/SettingsPage.razor
+++ b/ThemeManagement/Components/Pages/Settings/SettingsPage.razor
@@ -1,6 +1,5 @@
 @page "/settings"
 @rendermode InteractiveServer
-@inject NavigationManager Nav
 
 <PageTitle>設定・管理</PageTitle>
 

--- a/ThemeManagement/Program.cs
+++ b/ThemeManagement/Program.cs
@@ -61,7 +61,9 @@ app.MapGet("/api/backup/download", async (IConfiguration config, HttpContext con
     if (!File.Exists(dataSource))
         return Results.NotFound("DBファイルが見つかりません");
 
-    var tempFile = Path.Combine(Path.GetTempPath(), $"theme_backup_{DateTime.Now:yyyyMMdd_HHmmss}.db");
+    var tempFile = Path.Combine(
+        Path.GetTempPath(),
+        $"theme_backup_{DateTime.UtcNow:yyyyMMdd_HHmmss}_{Guid.NewGuid():N}.db");
     try
     {
         // VACUUM INTO で安全にコピー（WALのコミット済みデータを含む）

--- a/ThemeManagement/Program.cs
+++ b/ThemeManagement/Program.cs
@@ -74,14 +74,24 @@ app.MapGet("/api/backup/download", async (IConfiguration config, HttpContext con
         cmd.CommandText = $"VACUUM INTO '{escapedTempFile}'";
         await cmd.ExecuteNonQueryAsync();
 
-        var bytes = await File.ReadAllBytesAsync(tempFile);
         var fileName = Path.GetFileName(tempFile);
-        return Results.File(bytes, "application/octet-stream", fileName);
+
+        context.Response.OnCompleted(() =>
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+
+            return Task.CompletedTask;
+        });
+
+        return Results.PhysicalFile(tempFile, "application/octet-stream", fileName);
     }
-    finally
+    catch
     {
         if (File.Exists(tempFile))
             File.Delete(tempFile);
+
+        throw;
     }
 });
 

--- a/ThemeManagement/Program.cs
+++ b/ThemeManagement/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using MudBlazor.Services;
 using ThemeManagement.Components;
@@ -46,6 +47,40 @@ app.UseStatusCodePagesWithReExecute("/not-found", createScopeForStatusCodePages:
 app.UseHttpsRedirection();
 
 app.UseAntiforgery();
+
+// DB バックアップダウンロード
+app.MapGet("/api/backup/download", async (IConfiguration config, HttpContext context) =>
+{
+    var connStr = config.GetConnectionString("DefaultConnection") ?? "Data Source=theme_management.db";
+    // SQLiteのパスを抽出
+    var dataSource = connStr.Split(';')
+        .Select(p => p.Trim())
+        .FirstOrDefault(p => p.StartsWith("Data Source=", StringComparison.OrdinalIgnoreCase))
+        ?.Substring("Data Source=".Length) ?? "theme_management.db";
+
+    if (!File.Exists(dataSource))
+        return Results.NotFound("DBファイルが見つかりません");
+
+    var tempFile = Path.Combine(Path.GetTempPath(), $"theme_backup_{DateTime.Now:yyyyMMdd_HHmmss}.db");
+    try
+    {
+        // VACUUM INTO で安全にコピー（WALのコミット済みデータを含む）
+        using var conn = new SqliteConnection($"Data Source={dataSource}");
+        await conn.OpenAsync();
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = $"VACUUM INTO '{tempFile}'";
+        await cmd.ExecuteNonQueryAsync();
+
+        var bytes = await File.ReadAllBytesAsync(tempFile);
+        var fileName = Path.GetFileName(tempFile);
+        return Results.File(bytes, "application/octet-stream", fileName);
+    }
+    finally
+    {
+        if (File.Exists(tempFile))
+            File.Delete(tempFile);
+    }
+});
 
 app.MapStaticAssets();
 app.MapRazorComponents<App>()

--- a/ThemeManagement/Program.cs
+++ b/ThemeManagement/Program.cs
@@ -53,10 +53,10 @@ app.MapGet("/api/backup/download", async (IConfiguration config, HttpContext con
 {
     var connStr = config.GetConnectionString("DefaultConnection") ?? "Data Source=theme_management.db";
     // SQLiteのパスを抽出
-    var dataSource = connStr.Split(';')
-        .Select(p => p.Trim())
-        .FirstOrDefault(p => p.StartsWith("Data Source=", StringComparison.OrdinalIgnoreCase))
-        ?.Substring("Data Source=".Length) ?? "theme_management.db";
+    var sqliteConnectionStringBuilder = new SqliteConnectionStringBuilder(connStr);
+    var dataSource = string.IsNullOrWhiteSpace(sqliteConnectionStringBuilder.DataSource)
+        ? "theme_management.db"
+        : sqliteConnectionStringBuilder.DataSource;
 
     if (!File.Exists(dataSource))
         return Results.NotFound("DBファイルが見つかりません");

--- a/ThemeManagement/Program.cs
+++ b/ThemeManagement/Program.cs
@@ -70,7 +70,8 @@ app.MapGet("/api/backup/download", async (IConfiguration config, HttpContext con
         using var conn = new SqliteConnection($"Data Source={dataSource}");
         await conn.OpenAsync();
         var cmd = conn.CreateCommand();
-        cmd.CommandText = $"VACUUM INTO '{tempFile}'";
+        var escapedTempFile = tempFile.Replace("'", "''");
+        cmd.CommandText = $"VACUUM INTO '{escapedTempFile}'";
         await cmd.ExecuteNonQueryAsync();
 
         var bytes = await File.ReadAllBytesAsync(tempFile);


### PR DESCRIPTION
## 概要
SQLiteデータベースをVACUUM INTOで安全にコピーし、設定・管理ページ(/settings)からワンクリックでダウンロードできるようにした。

## 変更内容
- Settings/SettingsPage.razor 新規作成（バックアップダウンロードボタン）
- Program.cs に /api/backup/download エンドポイント追加
- NavMenuにリンク追加