### PR TITLE
feat: CSVエクスポート機能追加

### DIFF
--- a/ThemeManagement/Components/App.razor
+++ b/ThemeManagement/Components/App.razor
@@ -20,6 +20,7 @@
     <ReconnectModal />
     <script src="@Assets["_framework/blazor.web.js"]"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <script src="js/downloadHelper.js"></script>
 </body>
 
 </html>

--- a/ThemeManagement/Components/Pages/Home.razor
+++ b/ThemeManagement/Components/Pages/Home.razor
@@ -131,12 +131,18 @@
         _themeProgress = await DashboardService.GetThemeProgressAsync();
     }
 
+    private static string CsvField(string? value)
+    {
+        var escaped = (value ?? string.Empty).Replace("\"", "\"\"");
+        return $"\"{escaped}\"";
+    }
+
     private async Task ExportEngineerCsvAsync()
     {
         var sb = new System.Text.StringBuilder();
         sb.Append("エンジニア,等級,最大開発可能(h),割り当て合計(h),残余(h),稼働率(%)").Append("\r\n");
         foreach (var e in _engineerSummaries)
-            sb.Append($"\"{e.EngineerName}\",\"{e.GradeName}\",{e.MaxDevelopableHours:F1},{e.TotalAllocatedHours:F1},{e.RemainingHours:F1},{e.WorkRate:F1}").Append("\r\n");
+            sb.Append($"{CsvField(e.EngineerName)},{CsvField(e.GradeName)},{e.MaxDevelopableHours:F1},{e.TotalAllocatedHours:F1},{e.RemainingHours:F1},{e.WorkRate:F1}").Append("\r\n");
         await JS.InvokeVoidAsync("downloadCsv", $"engineer_summary_{_year}{_month:D2}_{DateTime.Now:HHmmss}.csv", sb.ToString());
     }
 
@@ -147,7 +153,7 @@
         foreach (var t in _themeProgress)
         {
             var completion = t.EstimatedCompletionYear.HasValue ? $"{t.EstimatedCompletionYear}年{t.EstimatedCompletionMonth}月" : "-";
-            sb.Append($"\"{t.ThemeName}\",{t.OrderAmount},{t.TotalAllocatedCost},{t.CarryOverAmount},{t.TotalAllocatedCost + t.CarryOverAmount},{t.ProgressRate:F1},{t.RemainingAmount},{completion}").Append("\r\n");
+            sb.Append($"{CsvField(t.ThemeName)},{t.OrderAmount},{t.TotalAllocatedCost},{t.CarryOverAmount},{t.TotalAllocatedCost + t.CarryOverAmount},{t.ProgressRate:F1},{t.RemainingAmount},{CsvField(completion)}").Append("\r\n");
         }
         await JS.InvokeVoidAsync("downloadCsv", $"theme_progress_{DateTime.Now:yyyyMMdd_HHmmss}.csv", sb.ToString());
     }

--- a/ThemeManagement/Components/Pages/Home.razor
+++ b/ThemeManagement/Components/Pages/Home.razor
@@ -1,6 +1,7 @@
 ﻿@page "/"
 @rendermode InteractiveServer
 @inject IDashboardService DashboardService
+@inject IJSRuntime JS
 
 <PageTitle>ダッシュボード</PageTitle>
 
@@ -14,7 +15,11 @@
     </MudStack>
 </MudPaper>
 
-<MudText Typo="Typo.h6" Class="mb-2">エンジニア稼働サマリ（@(_year)年@(_month)月）</MudText>
+<MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="mb-2">
+    <MudText Typo="Typo.h6">エンジニア稼働サマリ（@(_year)年@(_month)月）</MudText>
+    <MudButton Variant="Variant.Outlined" Color="Color.Success" Size="Size.Small"
+               StartIcon="@Icons.Material.Filled.FileDownload" OnClick="ExportEngineerCsvAsync">CSVエクスポート</MudButton>
+</MudStack>
 <MudTable Items="_engineerSummaries" Dense="true" Hover="true" Elevation="2" Class="mb-6"
           RowClassFunc="@((row, _) => row.MaxDevelopableHours > 0 && row.TotalAllocatedHours > row.MaxDevelopableHours ? "row-over"
                                     : row.MaxDevelopableHours > 0 && row.TotalAllocatedHours == 0 ? "row-unassigned"
@@ -60,7 +65,11 @@
     <NoRecordsContent><MudText>データがありません</MudText></NoRecordsContent>
 </MudTable>
 
-<MudText Typo="Typo.h6" Class="mb-2">テーマ進捗サマリ（アクティブ案件）</MudText>
+<MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="mb-2">
+    <MudText Typo="Typo.h6">テーマ進捗サマリ（アクティブ案件）</MudText>
+    <MudButton Variant="Variant.Outlined" Color="Color.Success" Size="Size.Small"
+               StartIcon="@Icons.Material.Filled.FileDownload" OnClick="ExportThemeCsvAsync">CSVエクスポート</MudButton>
+</MudStack>
 <MudTable Items="_themeProgress" Dense="true" Hover="true" Elevation="2"
           RowClassFunc="@((row, _) => row.ProgressRate > 100 ? "row-over" : "")">
     <HeaderContent>
@@ -120,5 +129,26 @@
     {
         _engineerSummaries = await DashboardService.GetEngineerSummaryAsync(_year, _month);
         _themeProgress = await DashboardService.GetThemeProgressAsync();
+    }
+
+    private async Task ExportEngineerCsvAsync()
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine("エンジニア,等級,最大開発可能(h),割り当て合計(h),残余(h),稼働率(%)");
+        foreach (var e in _engineerSummaries)
+            sb.AppendLine($"\"{e.EngineerName}\",\"{e.GradeName}\",{e.MaxDevelopableHours:F1},{e.TotalAllocatedHours:F1},{e.RemainingHours:F1},{e.WorkRate:F1}");
+        await JS.InvokeVoidAsync("downloadCsv", $"engineer_summary_{_year}{_month:D2}_{DateTime.Now:HHmmss}.csv", sb.ToString());
+    }
+
+    private async Task ExportThemeCsvAsync()
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine("テーマ名,受注金額,稼働コスト,前期繰越,合計コスト,消化率(%),残余金額,完了見込み");
+        foreach (var t in _themeProgress)
+        {
+            var completion = t.EstimatedCompletionYear.HasValue ? $"{t.EstimatedCompletionYear}年{t.EstimatedCompletionMonth}月" : "-";
+            sb.AppendLine($"\"{t.ThemeName}\",{t.OrderAmount},{t.TotalAllocatedCost},{t.CarryOverAmount},{t.TotalAllocatedCost + t.CarryOverAmount},{t.ProgressRate:F1},{t.RemainingAmount},{completion}");
+        }
+        await JS.InvokeVoidAsync("downloadCsv", $"theme_progress_{DateTime.Now:yyyyMMdd_HHmmss}.csv", sb.ToString());
     }
 }

--- a/ThemeManagement/Components/Pages/Home.razor
+++ b/ThemeManagement/Components/Pages/Home.razor
@@ -134,20 +134,20 @@
     private async Task ExportEngineerCsvAsync()
     {
         var sb = new System.Text.StringBuilder();
-        sb.AppendLine("エンジニア,等級,最大開発可能(h),割り当て合計(h),残余(h),稼働率(%)");
+        sb.Append("エンジニア,等級,最大開発可能(h),割り当て合計(h),残余(h),稼働率(%)").Append("\r\n");
         foreach (var e in _engineerSummaries)
-            sb.AppendLine($"\"{e.EngineerName}\",\"{e.GradeName}\",{e.MaxDevelopableHours:F1},{e.TotalAllocatedHours:F1},{e.RemainingHours:F1},{e.WorkRate:F1}");
+            sb.Append($"\"{e.EngineerName}\",\"{e.GradeName}\",{e.MaxDevelopableHours:F1},{e.TotalAllocatedHours:F1},{e.RemainingHours:F1},{e.WorkRate:F1}").Append("\r\n");
         await JS.InvokeVoidAsync("downloadCsv", $"engineer_summary_{_year}{_month:D2}_{DateTime.Now:HHmmss}.csv", sb.ToString());
     }
 
     private async Task ExportThemeCsvAsync()
     {
         var sb = new System.Text.StringBuilder();
-        sb.AppendLine("テーマ名,受注金額,稼働コスト,前期繰越,合計コスト,消化率(%),残余金額,完了見込み");
+        sb.Append("テーマ名,受注金額,稼働コスト,前期繰越,合計コスト,消化率(%),残余金額,完了見込み").Append("\r\n");
         foreach (var t in _themeProgress)
         {
             var completion = t.EstimatedCompletionYear.HasValue ? $"{t.EstimatedCompletionYear}年{t.EstimatedCompletionMonth}月" : "-";
-            sb.AppendLine($"\"{t.ThemeName}\",{t.OrderAmount},{t.TotalAllocatedCost},{t.CarryOverAmount},{t.TotalAllocatedCost + t.CarryOverAmount},{t.ProgressRate:F1},{t.RemainingAmount},{completion}");
+            sb.Append($"\"{t.ThemeName}\",{t.OrderAmount},{t.TotalAllocatedCost},{t.CarryOverAmount},{t.TotalAllocatedCost + t.CarryOverAmount},{t.ProgressRate:F1},{t.RemainingAmount},{completion}").Append("\r\n");
         }
         await JS.InvokeVoidAsync("downloadCsv", $"theme_progress_{DateTime.Now:yyyyMMdd_HHmmss}.csv", sb.ToString());
     }

--- a/ThemeManagement/Components/Pages/Themes/ThemeList.razor
+++ b/ThemeManagement/Components/Pages/Themes/ThemeList.razor
@@ -112,13 +112,33 @@
         _ => status
     };
 
+    private static string CsvField(string? value)
+    {
+        var escaped = (value ?? string.Empty).Replace("\"", "\"\"");
+        return $"\"{escaped}\"";
+    }
+
     private async Task ExportCsvAsync()
     {
         var sb = new System.Text.StringBuilder();
-        sb.AppendLine("テーマNo,テーマ名,受注区分,受注日,完了予定日,受注金額,状態");
+        sb.AppendLine(string.Join(",",
+            CsvField("テーマNo"),
+            CsvField("テーマ名"),
+            CsvField("受注区分"),
+            CsvField("受注日"),
+            CsvField("完了予定日"),
+            CsvField("受注金額"),
+            CsvField("状態")));
         foreach (var t in _themes)
         {
-            sb.AppendLine($"\"{t.ThemeNo}\",\"{t.Name}\",\"{t.OrderType}\",{t.OrderDate:yyyy/MM/dd},{t.EstimatedCompletionDate:yyyy/MM/dd},{t.OrderAmount},{StatusLabel(t.Status)}");
+            sb.AppendLine(string.Join(",",
+                CsvField(t.ThemeNo),
+                CsvField(t.Name),
+                CsvField(t.OrderType),
+                CsvField($"{t.OrderDate:yyyy/MM/dd}"),
+                CsvField($"{t.EstimatedCompletionDate:yyyy/MM/dd}"),
+                CsvField($"{t.OrderAmount}"),
+                CsvField(StatusLabel(t.Status))));
         }
         var filename = $"themes_{DateTime.Now:yyyyMMdd_HHmmss}.csv";
         await JS.InvokeVoidAsync("downloadCsv", filename, sb.ToString());

--- a/ThemeManagement/Components/Pages/Themes/ThemeList.razor
+++ b/ThemeManagement/Components/Pages/Themes/ThemeList.razor
@@ -3,6 +3,7 @@
 @inject IThemeService ThemeService
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService
+@inject IJSRuntime JS
 
 <PageTitle>テーマ・案件一覧</PageTitle>
 
@@ -13,6 +14,8 @@
                OnClick="OpenAddDialog">新規登録</MudButton>
     <MudButton Variant="Variant.Outlined" Color="Color.Secondary" StartIcon="@Icons.Material.Filled.UploadFile"
                OnClick="OpenCsvImportDialog">CSVインポート</MudButton>
+    <MudButton Variant="Variant.Outlined" Color="Color.Success" StartIcon="@Icons.Material.Filled.FileDownload"
+               OnClick="ExportCsvAsync">CSVエクスポート</MudButton>
     <MudCheckBox T="bool" Value="_showAll" ValueChanged="@(async v => { _showAll = v; await LoadAsync(); })" Label="完了・中止も表示" />
 </MudStack>
 
@@ -108,4 +111,16 @@
         "Cancelled" => "中止",
         _ => status
     };
+
+    private async Task ExportCsvAsync()
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine("テーマNo,テーマ名,受注区分,受注日,完了予定日,受注金額,状態");
+        foreach (var t in _themes)
+        {
+            sb.AppendLine($"\"{t.ThemeNo}\",\"{t.Name}\",\"{t.OrderType}\",{t.OrderDate:yyyy/MM/dd},{t.EstimatedCompletionDate:yyyy/MM/dd},{t.OrderAmount},{StatusLabel(t.Status)}");
+        }
+        var filename = $"themes_{DateTime.Now:yyyyMMdd_HHmmss}.csv";
+        await JS.InvokeVoidAsync("downloadCsv", filename, sb.ToString());
+    }
 }

--- a/ThemeManagement/wwwroot/js/downloadHelper.js
+++ b/ThemeManagement/wwwroot/js/downloadHelper.js
@@ -1,0 +1,13 @@
+// UTF-8 BOM付きCSVをブラウザでダウンロードする
+window.downloadCsv = function (filename, csvContent) {
+    const bom = '\uFEFF';
+    const blob = new Blob([bom + csvContent], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+};

--- a/ThemeManagement/wwwroot/js/downloadHelper.js
+++ b/ThemeManagement/wwwroot/js/downloadHelper.js
@@ -6,6 +6,7 @@ window.downloadCsv = function (filename, csvContent) {
     const a = document.createElement('a');
     a.href = url;
     a.download = filename;
+    a.style.display = 'none';
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);


### PR DESCRIPTION
## 概要
ダッシュボードのエンジニアサマリ・テーマ進捗、テーマ一覧ページにUTF-8 BOM付きCSVダウンロード機能を追加した。

## 変更内容
- wwwroot/js/downloadHelper.js 新規作成（BOM付きCSV生成）
- App.razor にscriptタグ追加
- ThemeList.razor にCSVエクスポートボタン追加
- Home.razor にエンジニア・テーマ各テーブルのCSVエクスポートボタン追加