### PR TITLE
feat: ダッシュボードにアラート・警告サマリ追加

### DIFF
--- a/ThemeManagement/Components/Pages/Home.razor
+++ b/ThemeManagement/Components/Pages/Home.razor
@@ -142,8 +142,13 @@
 
     private async Task LoadData()
     {
-        _engineerSummaries = await DashboardService.GetEngineerSummaryAsync(_year, _month);
-        _themeProgress = await DashboardService.GetThemeProgressAsync();
-        _alerts = await DashboardService.GetAlertsAsync(_year, _month);
+        var engineerSummariesTask = DashboardService.GetEngineerSummaryAsync(_year, _month);
+        var themeProgressTask = DashboardService.GetThemeProgressAsync();
+
+        await Task.WhenAll(engineerSummariesTask, themeProgressTask);
+
+        _engineerSummaries = await engineerSummariesTask;
+        _themeProgress = await themeProgressTask;
+        _alerts = await DashboardService.GetAlertsAsync(_year, _month, _engineerSummaries, _themeProgress);
     }
 }

--- a/ThemeManagement/Components/Pages/Home.razor
+++ b/ThemeManagement/Components/Pages/Home.razor
@@ -119,8 +119,8 @@
             {
                 var severity = alert.Severity switch
                 {
-                    "error" => Severity.Error,
-                    "warning" => Severity.Warning,
+                    AlertSeverity.Error => Severity.Error,
+                    AlertSeverity.Warning => Severity.Warning,
                     _ => Severity.Info
                 };
                 <MudAlert Severity="@severity" Dense="true">
@@ -149,6 +149,6 @@
 
         _engineerSummaries = await engineerSummariesTask;
         _themeProgress = await themeProgressTask;
-        _alerts = await DashboardService.GetAlertsAsync(_year, _month, _engineerSummaries, _themeProgress);
+        _alerts = DashboardService.GetAlerts(_year, _month, _engineerSummaries, _themeProgress);
     }
 }

--- a/ThemeManagement/Components/Pages/Home.razor
+++ b/ThemeManagement/Components/Pages/Home.razor
@@ -108,11 +108,35 @@
     <NoRecordsContent><MudText>アクティブなテーマがありません</MudText></NoRecordsContent>
 </MudTable>
 
+@if (_alerts.Count > 0)
+{
+    <MudText Typo="Typo.h6" Class="mb-2 mt-4">
+        <MudIcon Icon="@Icons.Material.Filled.NotificationsActive" Color="Color.Warning" Class="mr-1" />警告・アラート
+    </MudText>
+    <MudPaper Class="pa-3 mb-4" Elevation="2">
+        <MudStack Spacing="2">
+            @foreach (var alert in _alerts)
+            {
+                var severity = alert.Severity switch
+                {
+                    "error" => Severity.Error,
+                    "warning" => Severity.Warning,
+                    _ => Severity.Info
+                };
+                <MudAlert Severity="@severity" Dense="true">
+                    <MudText><strong>[@alert.Category]</strong> @alert.Message</MudText>
+                </MudAlert>
+            }
+        </MudStack>
+    </MudPaper>
+}
+
 @code {
     private int _year = DateTime.Now.Year;
     private int _month = DateTime.Now.Month;
     private List<EngineerWorkSummaryDto> _engineerSummaries = [];
     private List<ThemeProgressDto> _themeProgress = [];
+    private List<AlertItemDto> _alerts = [];
 
     protected override async Task OnInitializedAsync() => await LoadData();
 
@@ -120,5 +144,6 @@
     {
         _engineerSummaries = await DashboardService.GetEngineerSummaryAsync(_year, _month);
         _themeProgress = await DashboardService.GetThemeProgressAsync();
+        _alerts = await DashboardService.GetAlertsAsync(_year, _month);
     }
 }

--- a/ThemeManagement/Models/Dtos.cs
+++ b/ThemeManagement/Models/Dtos.cs
@@ -37,8 +37,15 @@ public record ThemeProgressDto(
     int? EstimatedCompletionMonth
 );
 
+public enum AlertSeverity
+{
+    Error,
+    Warning,
+    Info
+}
+
 public record AlertItemDto(
-    string Severity,    // "error" | "warning" | "info"
+    AlertSeverity Severity,
     string Category,
     string Message
 );

--- a/ThemeManagement/Models/Dtos.cs
+++ b/ThemeManagement/Models/Dtos.cs
@@ -34,7 +34,8 @@ public record ThemeProgressDto(
     decimal ProgressRate,
     decimal RemainingAmount,
     int? EstimatedCompletionYear,
-    int? EstimatedCompletionMonth
+    int? EstimatedCompletionMonth,
+    DateOnly? EstimatedCompletionDate
 );
 
 public enum AlertSeverity

--- a/ThemeManagement/Models/Dtos.cs
+++ b/ThemeManagement/Models/Dtos.cs
@@ -36,3 +36,9 @@ public record ThemeProgressDto(
     int? EstimatedCompletionYear,
     int? EstimatedCompletionMonth
 );
+
+public record AlertItemDto(
+    string Severity,    // "error" | "warning" | "info"
+    string Category,
+    string Message
+);

--- a/ThemeManagement/Services/DashboardService.cs
+++ b/ThemeManagement/Services/DashboardService.cs
@@ -8,6 +8,7 @@ public interface IDashboardService
 {
     Task<List<EngineerWorkSummaryDto>> GetEngineerSummaryAsync(int year, int month);
     Task<List<ThemeProgressDto>> GetThemeProgressAsync();
+    Task<List<AlertItemDto>> GetAlertsAsync(int year, int month);
 }
 
 public class DashboardService : IDashboardService
@@ -111,5 +112,39 @@ public class DashboardService : IDashboardService
         }
 
         return result;
+    }
+
+    public async Task<List<AlertItemDto>> GetAlertsAsync(int year, int month)
+    {
+        var alerts = new List<AlertItemDto>();
+
+        // -- エンジニア稼働アラート --
+        var summaries = await GetEngineerSummaryAsync(year, month);
+        foreach (var e in summaries)
+        {
+            if (e.MaxDevelopableHours > 0 && e.WorkRate > 120)
+                alerts.Add(new AlertItemDto("error", "稼働超過", $"{e.EngineerName} の稼働率が {e.WorkRate:F0}% です（{year}/{month}）"));
+            else if (e.MaxDevelopableHours > 0 && e.WorkRate > 100)
+                alerts.Add(new AlertItemDto("warning", "稼働超過", $"{e.EngineerName} の稼働率が {e.WorkRate:F0}% です（{year}/{month}）"));
+            else if (e.MaxDevelopableHours > 0 && e.TotalAllocatedHours == 0)
+                alerts.Add(new AlertItemDto("warning", "未割当", $"{e.EngineerName} に{year}/{month}の工数が割り当てられていません"));
+        }
+
+        // -- テーマアラート --
+        var themes = await _db.Themes.Where(t => t.Status == "Active").ToListAsync();
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        var themeProgress = await GetThemeProgressAsync();
+        foreach (var t in themeProgress)
+        {
+            if (t.ProgressRate > 100)
+                alerts.Add(new AlertItemDto("error", "予算超過", $"テーマ「{t.ThemeName}」が予算超過です（消化率 {t.ProgressRate:F0}%）"));
+        }
+        foreach (var t in themes)
+        {
+            if (t.EstimatedCompletionDate < today)
+                alerts.Add(new AlertItemDto("warning", "完了期限超過", $"テーマ「{t.Name}」の完了予定日（{t.EstimatedCompletionDate:yyyy/MM/dd}）を過ぎています"));
+        }
+
+        return alerts.OrderBy(a => a.Severity == "error" ? 0 : a.Severity == "warning" ? 1 : 2).ToList();
     }
 }

--- a/ThemeManagement/Services/DashboardService.cs
+++ b/ThemeManagement/Services/DashboardService.cs
@@ -8,7 +8,7 @@ public interface IDashboardService
 {
     Task<List<EngineerWorkSummaryDto>> GetEngineerSummaryAsync(int year, int month);
     Task<List<ThemeProgressDto>> GetThemeProgressAsync();
-    Task<List<AlertItemDto>> GetAlertsAsync(int year, int month);
+    List<AlertItemDto> GetAlerts(int year, int month, List<EngineerWorkSummaryDto> summaries, List<ThemeProgressDto> themeProgress);
 }
 
 public class DashboardService : IDashboardService
@@ -108,43 +108,39 @@ public class DashboardService : IDashboardService
             result.Add(new ThemeProgressDto(
                 theme.Id, theme.Name, theme.Status,
                 theme.OrderAmount, allocCost, carryOver, progressRate, remaining,
-                estYear, estMonth));
+                estYear, estMonth,
+                theme.EstimatedCompletionDate));
         }
 
         return result;
     }
 
-    public async Task<List<AlertItemDto>> GetAlertsAsync(int year, int month)
+    public List<AlertItemDto> GetAlerts(int year, int month, List<EngineerWorkSummaryDto> summaries, List<ThemeProgressDto> themeProgress)
     {
         var alerts = new List<AlertItemDto>();
+        var today = DateOnly.FromDateTime(DateTime.Today);
 
         // -- エンジニア稼働アラート --
-        var summaries = await GetEngineerSummaryAsync(year, month);
         foreach (var e in summaries)
         {
             if (e.MaxDevelopableHours > 0 && e.WorkRate > 120)
-                alerts.Add(new AlertItemDto("error", "稼働超過", $"{e.EngineerName} の稼働率が {e.WorkRate:F0}% です（{year}/{month}）"));
+                alerts.Add(new AlertItemDto(AlertSeverity.Error, "稼働超過", $"{e.EngineerName} の稼働率が {e.WorkRate:F0}% です（{year}/{month}）"));
             else if (e.MaxDevelopableHours > 0 && e.WorkRate > 100)
-                alerts.Add(new AlertItemDto("warning", "稼働超過", $"{e.EngineerName} の稼働率が {e.WorkRate:F0}% です（{year}/{month}）"));
+                alerts.Add(new AlertItemDto(AlertSeverity.Warning, "稼働超過", $"{e.EngineerName} の稼働率が {e.WorkRate:F0}% です（{year}/{month}）"));
             else if (e.MaxDevelopableHours > 0 && e.TotalAllocatedHours == 0)
-                alerts.Add(new AlertItemDto("warning", "未割当", $"{e.EngineerName} に{year}/{month}の工数が割り当てられていません"));
+                alerts.Add(new AlertItemDto(AlertSeverity.Warning, "未割当", $"{e.EngineerName} に{year}/{month}の工数が割り当てられていません"));
         }
 
         // -- テーマアラート --
-        var themes = await _db.Themes.Where(t => t.Status == "Active").ToListAsync();
-        var today = DateOnly.FromDateTime(DateTime.Today);
-        var themeProgress = await GetThemeProgressAsync();
         foreach (var t in themeProgress)
         {
             if (t.ProgressRate > 100)
-                alerts.Add(new AlertItemDto("error", "予算超過", $"テーマ「{t.ThemeName}」が予算超過です（消化率 {t.ProgressRate:F0}%）"));
-        }
-        foreach (var t in themes)
-        {
-            if (t.EstimatedCompletionDate < today)
-                alerts.Add(new AlertItemDto("warning", "完了期限超過", $"テーマ「{t.Name}」の完了予定日（{t.EstimatedCompletionDate:yyyy/MM/dd}）を過ぎています"));
+                alerts.Add(new AlertItemDto(AlertSeverity.Error, "予算超過", $"テーマ「{t.ThemeName}」が予算超過です（消化率 {t.ProgressRate:F0}%）"));
+
+            if (t.EstimatedCompletionDate.HasValue && t.EstimatedCompletionDate.Value < today)
+                alerts.Add(new AlertItemDto(AlertSeverity.Warning, "完了期限超過", $"テーマ「{t.ThemeName}」の完了予定日（{t.EstimatedCompletionDate.Value:yyyy/MM/dd}）を過ぎています"));
         }
 
-        return alerts.OrderBy(a => a.Severity == "error" ? 0 : a.Severity == "warning" ? 1 : 2).ToList();
+        return alerts.OrderBy(a => a.Severity).ToList();
     }
 }


### PR DESCRIPTION
## 概要
ダッシュボード下部に稼働超過・未割当エンジニア・予算超過・期限超過のアラートパネルを追加した。

## 変更内容
- DashboardService に GetAlertsAsync() 追加（稼働率120%超→error、100%超→warning等）
- Models/Dtos.cs に AlertItemDto 追加
- Home.razor にアラートパネルUI追加