### PR TITLE
feat: テーマ工数割当に前月一括コピー機能追加

### DIFF
--- a/ThemeManagement/Components/Pages/Themes/ThemeAllocation.razor
+++ b/ThemeManagement/Components/Pages/Themes/ThemeAllocation.razor
@@ -40,6 +40,8 @@ else
 
     <MudButton Variant="Variant.Outlined" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Add"
                OnClick="OpenAddDialog" Class="mb-3">エンジニア追加</MudButton>
+    <MudButton Variant="Variant.Outlined" Color="Color.Secondary" StartIcon="@Icons.Material.Filled.ContentCopy"
+               OnClick="CopyFromPrevMonthAsync" Class="mb-3 ml-2">前月割当をコピー</MudButton>
 
     <MudTable Items="_allocations" Dense="true" Hover="true" Elevation="2">
         <HeaderContent>
@@ -166,6 +168,25 @@ else
     }
 
     private void GoBack() => Nav.NavigateTo("/themes");
+
+    private async Task CopyFromPrevMonthAsync()
+    {
+        var prevDate = new DateTime(_year, _month, 1).AddMonths(-1);
+        var confirmed = await ConfirmAsync(
+            "前月割当コピー",
+            $"{prevDate.Year}/{prevDate.Month:D2} の割り当てを {_year}/{_month:D2} にコピーしますか？（既存データは上書きされます）",
+            "コピー実行");
+        if (!confirmed) return;
+
+        var count = await AllocationService.CopyFromPreviousMonthAsync(ThemeId, _year, _month);
+        if (count == 0)
+            Snackbar.Add($"{prevDate.Year}/{prevDate.Month:D2} の割り当てデータがありません", Severity.Warning);
+        else
+        {
+            Snackbar.Add($"{count} 件の割り当てをコピーしました", Severity.Success);
+            await LoadAllocations();
+        }
+    }
 
     private async Task<bool> ConfirmAsync(string title, string message, string confirmText = "OK")
     {

--- a/ThemeManagement/Components/Pages/Themes/ThemeAllocation.razor
+++ b/ThemeManagement/Components/Pages/Themes/ThemeAllocation.razor
@@ -178,13 +178,33 @@ else
             "コピー実行");
         if (!confirmed) return;
 
-        var count = await AllocationService.CopyFromPreviousMonthAsync(ThemeId, _year, _month);
+        int count;
+        try
+        {
+            count = await AllocationService.CopyFromPreviousMonthAsync(ThemeId, _year, _month);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "前月割り当てのコピー中にエラーが発生しました (ThemeId={ThemeId}, Year={Year}, Month={Month})", ThemeId, _year, _month);
+            Snackbar.Add("前月割り当てのコピー中にエラーが発生しました", Severity.Error);
+            return;
+        }
+
         if (count == 0)
             Snackbar.Add($"{prevDate.Year}/{prevDate.Month:D2} の割り当てデータがありません", Severity.Warning);
         else
         {
             Snackbar.Add($"{count} 件の割り当てをコピーしました", Severity.Success);
-            await LoadAllocations();
+
+            try
+            {
+                await LoadAllocations();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "前月割り当てコピー後の再読込中にエラーが発生しました (ThemeId={ThemeId}, Year={Year}, Month={Month})", ThemeId, _year, _month);
+                Snackbar.Add("コピーは完了しましたが、一覧の再読込に失敗しました", Severity.Warning);
+            }
         }
     }
 

--- a/ThemeManagement/Services/AllocationService.cs
+++ b/ThemeManagement/Services/AllocationService.cs
@@ -203,30 +203,24 @@ public class AllocationService : IAllocationService
 
         if (prevAllocations.Count == 0) return 0;
 
+        await using var transaction = await _db.Database.BeginTransactionAsync();
+
         int copied = 0;
-        foreach (var prev in prevAllocations)
+        try
         {
-            var existing = await _db.EngineerThemeAllocations
-                .FirstOrDefaultAsync(a => a.EngineerId == prev.EngineerId && a.ThemeId == themeId
-                                          && a.Year == year && a.Month == month);
-            if (existing == null)
+            foreach (var prev in prevAllocations)
             {
-                _db.EngineerThemeAllocations.Add(new EngineerThemeAllocation
-                {
-                    EngineerId = prev.EngineerId,
-                    ThemeId = themeId,
-                    Year = year,
-                    Month = month,
-                    AllocatedHours = prev.AllocatedHours
-                });
+                await UpsertAllocationAsync(prev.EngineerId, themeId, year, month, prev.AllocatedHours);
+                copied++;
             }
-            else
-            {
-                existing.AllocatedHours = prev.AllocatedHours;
-            }
-            copied++;
+
+            await transaction.CommitAsync();
+            return copied;
         }
-        await _db.SaveChangesAsync();
-        return copied;
+        catch
+        {
+            await transaction.RollbackAsync();
+            throw;
+        }
     }
 }

--- a/ThemeManagement/Services/AllocationService.cs
+++ b/ThemeManagement/Services/AllocationService.cs
@@ -17,6 +17,8 @@ public interface IAllocationService
     Task UpsertAllocationAsync(int engineerId, int themeId, int year, int month, decimal hours);
     Task UpsertAllocationNoValidationAsync(int engineerId, int themeId, int year, int month, decimal hours);
     Task DeleteAllocationAsync(int id);
+    /// <summary>前月の割当てを指定月に一括コピーします（既存データは上書き）</summary>
+    Task<int> CopyFromPreviousMonthAsync(int themeId, int year, int month);
 }
 
 public class AllocationService : IAllocationService
@@ -186,5 +188,45 @@ public class AllocationService : IAllocationService
             existing.AllocatedHours = hours;
         }
         await _db.SaveChangesAsync();
+    }
+
+    public async Task<int> CopyFromPreviousMonthAsync(int themeId, int year, int month)
+    {
+        // 前月の計算
+        var prevDate = new DateTime(year, month, 1).AddMonths(-1);
+        int prevYear = prevDate.Year;
+        int prevMonth = prevDate.Month;
+
+        var prevAllocations = await _db.EngineerThemeAllocations
+            .Where(a => a.ThemeId == themeId && a.Year == prevYear && a.Month == prevMonth)
+            .ToListAsync();
+
+        if (prevAllocations.Count == 0) return 0;
+
+        int copied = 0;
+        foreach (var prev in prevAllocations)
+        {
+            var existing = await _db.EngineerThemeAllocations
+                .FirstOrDefaultAsync(a => a.EngineerId == prev.EngineerId && a.ThemeId == themeId
+                                          && a.Year == year && a.Month == month);
+            if (existing == null)
+            {
+                _db.EngineerThemeAllocations.Add(new EngineerThemeAllocation
+                {
+                    EngineerId = prev.EngineerId,
+                    ThemeId = themeId,
+                    Year = year,
+                    Month = month,
+                    AllocatedHours = prev.AllocatedHours
+                });
+            }
+            else
+            {
+                existing.AllocatedHours = prev.AllocatedHours;
+            }
+            copied++;
+        }
+        await _db.SaveChangesAsync();
+        return copied;
     }
 }


### PR DESCRIPTION
## 概要
テーマ工数割当画面で「前月割当をコピー」ボタンを押すと、前月の割当をそのまま当月にコピーできるようにした。

## 変更内容
- AllocationService に CopyFromPreviousMonthAsync() 追加
- ThemeAllocation.razor にコピーボタンと確認ダイアログ追加