### PR TITLE
feat: テーマステータスを7段階に細分化

### DIFF
--- a/ThemeManagement/Components/Pages/Themes/ThemeEditDialog.razor
+++ b/ThemeManagement/Components/Pages/Themes/ThemeEditDialog.razor
@@ -19,8 +19,12 @@
                            Required="true" DateFormat="yyyy/MM/dd" />
             <MudNumericField T="decimal" @bind-Value="Theme.OrderAmount" Label="受注金額（円）" Min="1" Required="true" />
             <MudSelect T="string" @bind-Value="Theme.Status" Label="状態" Required="true">
+                <MudSelectItem T="string" Value="@("Quoting")">見積中</MudSelectItem>
+                <MudSelectItem T="string" Value="@("Confirmed")">受注確定</MudSelectItem>
                 <MudSelectItem T="string" Value="@("Active")">進行中</MudSelectItem>
+                <MudSelectItem T="string" Value="@("OnHold")">一時停止</MudSelectItem>
                 <MudSelectItem T="string" Value="@("Completed")">完了</MudSelectItem>
+                <MudSelectItem T="string" Value="@("Lost")">失注</MudSelectItem>
                 <MudSelectItem T="string" Value="@("Cancelled")">中止</MudSelectItem>
             </MudSelect>
             @if (Theme.Status == "Completed")

--- a/ThemeManagement/Components/Pages/Themes/ThemeList.razor
+++ b/ThemeManagement/Components/Pages/Themes/ThemeList.razor
@@ -95,16 +95,24 @@
 
     private static Color StatusColor(string status) => status switch
     {
+        "Quoting" => Color.Warning,
+        "Confirmed" => Color.Tertiary,
         "Active" => Color.Success,
+        "OnHold" => Color.Dark,
         "Completed" => Color.Info,
+        "Lost" => Color.Error,
         "Cancelled" => Color.Default,
         _ => Color.Default
     };
 
     private static string StatusLabel(string status) => status switch
     {
+        "Quoting" => "見積中",
+        "Confirmed" => "受注確定",
         "Active" => "進行中",
+        "OnHold" => "一時停止",
         "Completed" => "完了",
+        "Lost" => "失注",
         "Cancelled" => "中止",
         _ => status
     };

--- a/ThemeManagement/Domain/Entities/ThemeStatus.cs
+++ b/ThemeManagement/Domain/Entities/ThemeStatus.cs
@@ -1,0 +1,18 @@
+namespace ThemeManagement.Domain.Entities;
+
+public static class ThemeStatus
+{
+    public const string Quoting = "Quoting";
+    public const string Confirmed = "Confirmed";
+    public const string Active = "Active";
+    public const string OnHold = "OnHold";
+    public const string Completed = "Completed";
+    public const string Lost = "Lost";
+    public const string Cancelled = "Cancelled";
+
+    /// <summary>
+    /// 「アクティブ」とみなすステータスの集合（見積中・受注確定・進行中・一時停止）
+    /// </summary>
+    public static readonly HashSet<string> ActiveStatuses =
+        [Quoting, Confirmed, Active, OnHold];
+}

--- a/ThemeManagement/Services/DashboardService.cs
+++ b/ThemeManagement/Services/DashboardService.cs
@@ -57,7 +57,7 @@ public class DashboardService : IDashboardService
     public async Task<List<ThemeProgressDto>> GetThemeProgressAsync()
     {
         var themes = await _db.Themes
-            .Where(t => t.Status == "Active")
+            .Where(t => t.Status == "Active" || t.Status == "Confirmed")
             .OrderByDescending(t => t.OrderDate)
             .ToListAsync();
 

--- a/ThemeManagement/Services/DashboardService.cs
+++ b/ThemeManagement/Services/DashboardService.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using ThemeManagement.Data;
+using ThemeManagement.Domain.Entities;
 using ThemeManagement.Models;
 
 namespace ThemeManagement.Services;
@@ -57,7 +58,7 @@ public class DashboardService : IDashboardService
     public async Task<List<ThemeProgressDto>> GetThemeProgressAsync()
     {
         var themes = await _db.Themes
-            .Where(t => t.Status == "Active" || t.Status == "Confirmed")
+            .Where(t => ThemeStatus.ActiveStatuses.Contains(t.Status))
             .OrderByDescending(t => t.OrderDate)
             .ToListAsync();
 

--- a/ThemeManagement/Services/ThemeService.cs
+++ b/ThemeManagement/Services/ThemeService.cs
@@ -21,9 +21,7 @@ public class ThemeService : IThemeService
     {
         var query = _db.Themes.AsNoTracking().AsQueryable();
         if (activeOnly)
-            // 見積中・受注確定・進行中・一時停止を「アクティブ」とみなす
-            query = query.Where(t => t.Status == "Quoting" || t.Status == "Confirmed"
-                                  || t.Status == "Active" || t.Status == "OnHold");
+            query = query.Where(t => ThemeStatus.ActiveStatuses.Contains(t.Status));
         return query.OrderByDescending(t => t.OrderDate).ToListAsync();
     }
 

--- a/ThemeManagement/Services/ThemeService.cs
+++ b/ThemeManagement/Services/ThemeService.cs
@@ -21,7 +21,9 @@ public class ThemeService : IThemeService
     {
         var query = _db.Themes.AsNoTracking().AsQueryable();
         if (activeOnly)
-            query = query.Where(t => t.Status == "Active");
+            // 見積中・受注確定・進行中・一時停止を「アクティブ」とみなす
+            query = query.Where(t => t.Status == "Quoting" || t.Status == "Confirmed"
+                                  || t.Status == "Active" || t.Status == "OnHold");
         return query.OrderByDescending(t => t.OrderDate).ToListAsync();
     }
 


### PR DESCRIPTION
## 概要
テーマのステータスを従来の3種類から7種類に拡張した。

## ステータス一覧
| 値 | 表示 |
|---|---|
| Quoting | 見積中 |
| Confirmed | 受注確定 |
| Active | 進行中 |
| OnHold | 一時停止 |
| Completed | 完了 |
| Lost | 失注 |
| Cancelled | 中止 |

## 変更内容
- ThemeEditDialog.razor のステータス選択肢を拡張
- ThemeService.cs のアクティブフィルタを更新
- ダッシュボードのテーマ進捗表示条件を更新