### PR TITLE
feat: グレード単価変更履歴管理追加

### DIFF
--- a/ThemeManagement/Components/Pages/Grades/GradeEditDialog.razor
+++ b/ThemeManagement/Components/Pages/Grades/GradeEditDialog.razor
@@ -1,6 +1,7 @@
 @inject IGradeService GradeService
 @inject ISnackbar Snackbar
 @inject ILogger<GradeEditDialog> Logger
+@using ThemeManagement.Domain.Entities
 
 <MudDialog>
     <DialogContent>
@@ -8,6 +9,26 @@
             <MudTextField @bind-Value="Grade.Name" Label="等級名" Required="true" Immediate="true" />
             <MudNumericField T="decimal" @bind-Value="Grade.UnitSalePrice" Label="売価（円/h）" Min="0" Required="true" />
             <MudNumericField T="decimal" @bind-Value="Grade.UnitCostPrice" Label="原価（円/h）" Min="0" Required="true" />
+
+            @if (Grade.Id != 0 && _histories.Count > 0)
+            {
+                <MudExpansionPanels Elevation="0">
+                    <MudExpansionPanel Text="単価変更履歴" Dense="true">
+                        <MudTable Items="_histories" Dense="true" Elevation="0">
+                            <HeaderContent>
+                                <MudTh>適用開始日</MudTh>
+                                <MudTh Style="text-align:right">売価(円/h)</MudTh>
+                                <MudTh Style="text-align:right">原価(円/h)</MudTh>
+                            </HeaderContent>
+                            <RowTemplate>
+                                <MudTd>@context.ValidFrom.ToString("yyyy/MM/dd")</MudTd>
+                                <MudTd Style="text-align:right">@context.UnitSalePrice.ToString("N0")</MudTd>
+                                <MudTd Style="text-align:right">@context.UnitCostPrice.ToString("N0")</MudTd>
+                            </RowTemplate>
+                        </MudTable>
+                    </MudExpansionPanel>
+                </MudExpansionPanels>
+            }
         </MudStack>
     </DialogContent>
     <DialogActions>
@@ -19,6 +40,14 @@
 @code {
     [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = null!;
     [Parameter] public Grade Grade { get; set; } = new();
+
+    private List<GradePriceHistory> _histories = [];
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (Grade.Id != 0)
+            _histories = await GradeService.GetPriceHistoriesAsync(Grade.Id);
+    }
 
     private async Task Submit()
     {

--- a/ThemeManagement/Components/Pages/Grades/GradeEditDialog.razor
+++ b/ThemeManagement/Components/Pages/Grades/GradeEditDialog.razor
@@ -47,6 +47,8 @@
     {
         if (Grade.Id != 0)
             _histories = await GradeService.GetPriceHistoriesAsync(Grade.Id);
+        else
+            _histories = [];
     }
 
     private async Task Submit()

--- a/ThemeManagement/Data/AppDbContext.cs
+++ b/ThemeManagement/Data/AppDbContext.cs
@@ -14,6 +14,7 @@ public class AppDbContext : DbContext
     public DbSet<Theme> Themes => Set<Theme>();
     public DbSet<EngineerThemeAllocation> EngineerThemeAllocations => Set<EngineerThemeAllocation>();
     public DbSet<ThemeCarryOver> ThemeCarryOvers => Set<ThemeCarryOver>();
+    public DbSet<GradePriceHistory> GradePriceHistories => Set<GradePriceHistory>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/ThemeManagement/Domain/Entities/Grade.cs
+++ b/ThemeManagement/Domain/Entities/Grade.cs
@@ -10,4 +10,5 @@ public class Grade
     public DateTime UpdatedAt { get; set; }
 
     public ICollection<Engineer> Engineers { get; set; } = new List<Engineer>();
+    public ICollection<GradePriceHistory> PriceHistories { get; set; } = new List<GradePriceHistory>();
 }

--- a/ThemeManagement/Domain/Entities/GradePriceHistory.cs
+++ b/ThemeManagement/Domain/Entities/GradePriceHistory.cs
@@ -1,0 +1,14 @@
+namespace ThemeManagement.Domain.Entities;
+
+/// <summary>グレード単価の変更履歴</summary>
+public class GradePriceHistory
+{
+    public int Id { get; set; }
+    public int GradeId { get; set; }
+    public Grade Grade { get; set; } = null!;
+    /// <summary>この単価が有効になった日（グレード単価変更日）</summary>
+    public DateOnly ValidFrom { get; set; }
+    public decimal UnitSalePrice { get; set; }
+    public decimal UnitCostPrice { get; set; }
+    public DateTime CreatedAt { get; set; }
+}

--- a/ThemeManagement/Migrations/20260430122713_AddGradePriceHistory.Designer.cs
+++ b/ThemeManagement/Migrations/20260430122713_AddGradePriceHistory.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ThemeManagement.Data;
 
@@ -10,9 +11,11 @@ using ThemeManagement.Data;
 namespace ThemeManagement.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260430122713_AddGradePriceHistory")]
+    partial class AddGradePriceHistory
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/ThemeManagement/Migrations/20260430122713_AddGradePriceHistory.cs
+++ b/ThemeManagement/Migrations/20260430122713_AddGradePriceHistory.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ThemeManagement.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGradePriceHistory : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "GradePriceHistories",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    GradeId = table.Column<int>(type: "INTEGER", nullable: false),
+                    ValidFrom = table.Column<DateOnly>(type: "TEXT", nullable: false),
+                    UnitSalePrice = table.Column<decimal>(type: "TEXT", nullable: false),
+                    UnitCostPrice = table.Column<decimal>(type: "TEXT", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GradePriceHistories", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_GradePriceHistories_Grades_GradeId",
+                        column: x => x.GradeId,
+                        principalTable: "Grades",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GradePriceHistories_GradeId",
+                table: "GradePriceHistories",
+                column: "GradeId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "GradePriceHistories");
+        }
+    }
+}

--- a/ThemeManagement/Services/GradeService.cs
+++ b/ThemeManagement/Services/GradeService.cs
@@ -11,6 +11,7 @@ public interface IGradeService
     Task SaveAsync(Grade grade);
     Task DeleteAsync(int id);
     Task<bool> IsUsedAsync(int id);
+    Task<List<GradePriceHistory>> GetPriceHistoriesAsync(int gradeId);
 }
 
 public class GradeService : IGradeService
@@ -27,18 +28,44 @@ public class GradeService : IGradeService
     public async Task SaveAsync(Grade grade)
     {
         if (grade.Id == 0)
+        {
             _db.Grades.Add(grade);
+            await _db.SaveChangesAsync();
+            // 新規作成時の初期単価を履歴に記録
+            _db.GradePriceHistories.Add(new GradePriceHistory
+            {
+                GradeId = grade.Id,
+                ValidFrom = DateOnly.FromDateTime(DateTime.Today),
+                UnitSalePrice = grade.UnitSalePrice,
+                UnitCostPrice = grade.UnitCostPrice
+            });
+            await _db.SaveChangesAsync();
+        }
         else
         {
             var existing = await _db.Grades.FindAsync(grade.Id);
             if (existing != null)
             {
+                bool priceChanged = existing.UnitSalePrice != grade.UnitSalePrice
+                                 || existing.UnitCostPrice != grade.UnitCostPrice;
                 existing.Name = grade.Name;
                 existing.UnitSalePrice = grade.UnitSalePrice;
                 existing.UnitCostPrice = grade.UnitCostPrice;
+
+                if (priceChanged)
+                {
+                    // 単価変更時に履歴を追加
+                    _db.GradePriceHistories.Add(new GradePriceHistory
+                    {
+                        GradeId = grade.Id,
+                        ValidFrom = DateOnly.FromDateTime(DateTime.Today),
+                        UnitSalePrice = grade.UnitSalePrice,
+                        UnitCostPrice = grade.UnitCostPrice
+                    });
+                }
             }
+            await _db.SaveChangesAsync();
         }
-        await _db.SaveChangesAsync();
     }
 
     public async Task DeleteAsync(int id)
@@ -53,4 +80,11 @@ public class GradeService : IGradeService
 
     public Task<bool> IsUsedAsync(int id) =>
         _db.Engineers.AnyAsync(e => e.GradeId == id);
+
+    public Task<List<GradePriceHistory>> GetPriceHistoriesAsync(int gradeId) =>
+        _db.GradePriceHistories
+            .AsNoTracking()
+            .Where(h => h.GradeId == gradeId)
+            .OrderByDescending(h => h.ValidFrom)
+            .ToListAsync();
 }

--- a/ThemeManagement/Services/GradeService.cs
+++ b/ThemeManagement/Services/GradeService.cs
@@ -29,17 +29,27 @@ public class GradeService : IGradeService
     {
         if (grade.Id == 0)
         {
-            _db.Grades.Add(grade);
-            await _db.SaveChangesAsync();
-            // 新規作成時の初期単価を履歴に記録
-            _db.GradePriceHistories.Add(new GradePriceHistory
+            await using var transaction = await _db.Database.BeginTransactionAsync();
+            try
             {
-                GradeId = grade.Id,
-                ValidFrom = DateOnly.FromDateTime(DateTime.Today),
-                UnitSalePrice = grade.UnitSalePrice,
-                UnitCostPrice = grade.UnitCostPrice
-            });
-            await _db.SaveChangesAsync();
+                _db.Grades.Add(grade);
+                await _db.SaveChangesAsync();
+                // 新規作成時の初期単価を履歴に記録
+                _db.GradePriceHistories.Add(new GradePriceHistory
+                {
+                    GradeId = grade.Id,
+                    ValidFrom = DateOnly.FromDateTime(DateTime.Today),
+                    UnitSalePrice = grade.UnitSalePrice,
+                    UnitCostPrice = grade.UnitCostPrice
+                });
+                await _db.SaveChangesAsync();
+                await transaction.CommitAsync();
+            }
+            catch
+            {
+                await transaction.RollbackAsync();
+                throw;
+            }
         }
         else
         {

--- a/ThemeManagement/Services/GradeService.cs
+++ b/ThemeManagement/Services/GradeService.cs
@@ -35,13 +35,7 @@ public class GradeService : IGradeService
                 _db.Grades.Add(grade);
                 await _db.SaveChangesAsync();
                 // 新規作成時の初期単価を履歴に記録
-                _db.GradePriceHistories.Add(new GradePriceHistory
-                {
-                    GradeId = grade.Id,
-                    ValidFrom = DateOnly.FromDateTime(DateTime.Today),
-                    UnitSalePrice = grade.UnitSalePrice,
-                    UnitCostPrice = grade.UnitCostPrice
-                });
+                AddPriceHistoryEntry(grade.Id, grade.UnitSalePrice, grade.UnitCostPrice);
                 await _db.SaveChangesAsync();
                 await transaction.CommitAsync();
             }
@@ -65,17 +59,22 @@ public class GradeService : IGradeService
                 if (priceChanged)
                 {
                     // 単価変更時に履歴を追加
-                    _db.GradePriceHistories.Add(new GradePriceHistory
-                    {
-                        GradeId = grade.Id,
-                        ValidFrom = DateOnly.FromDateTime(DateTime.Today),
-                        UnitSalePrice = grade.UnitSalePrice,
-                        UnitCostPrice = grade.UnitCostPrice
-                    });
+                    AddPriceHistoryEntry(grade.Id, grade.UnitSalePrice, grade.UnitCostPrice);
                 }
             }
             await _db.SaveChangesAsync();
         }
+    }
+
+    private void AddPriceHistoryEntry(int gradeId, decimal unitSalePrice, decimal unitCostPrice)
+    {
+        _db.GradePriceHistories.Add(new GradePriceHistory
+        {
+            GradeId = gradeId,
+            ValidFrom = DateOnly.FromDateTime(DateTime.Today),
+            UnitSalePrice = unitSalePrice,
+            UnitCostPrice = unitCostPrice
+        });
     }
 
     public async Task DeleteAsync(int id)

--- a/ThemeManagement/Services/GradeService.cs
+++ b/ThemeManagement/Services/GradeService.cs
@@ -96,5 +96,6 @@ public class GradeService : IGradeService
             .AsNoTracking()
             .Where(h => h.GradeId == gradeId)
             .OrderByDescending(h => h.ValidFrom)
+            .ThenByDescending(h => h.Id)
             .ToListAsync();
 }


### PR DESCRIPTION
## 概要
グレードの単価を変更するたびに履歴を自動記録し、等級マスタの編集ダイアログで確認できるようにした。

## 変更内容
- Domain/Entities/GradePriceHistory.cs 新規作成
- Grade.cs にナビゲーションプロパティ追加
- AppDbContext.cs に GradePriceHistories DbSet追加
- GradeService.SaveAsync() で単価変更時に履歴自動記録
- GradeEditDialog.razor でMudExpansionPanelにて履歴テーブル表示
- マイグレーション AddGradePriceHistory 追加