### PR TITLE
feat: NavMenuに設定・管理ページへのリンクを追加

### DIFF
--- a/ThemeManagement/Components/Layout/NavMenu.razor
+++ b/ThemeManagement/Components/Layout/NavMenu.razor
@@ -8,5 +8,6 @@
     <MudNavGroup Title="レポート" Icon="@Icons.Material.Filled.BarChart" Expanded="true">
         <MudNavLink Href="/report/profitability" Icon="@Icons.Material.Filled.AttachMoney">採算レポート</MudNavLink>
     </MudNavGroup>
+    <MudNavLink Href="/settings" Icon="@Icons.Material.Filled.Settings">設定・管理</MudNavLink>
 </MudNavMenu>
 


### PR DESCRIPTION
This pull request makes a small update to the navigation menu by adding a new link for settings and management.

- Added a `MudNavLink` to the navigation menu in `NavMenu.razor` for accessing the settings and management page.